### PR TITLE
Refactor smooth scrolling to native API and drop jQuery hooks

### DIFF
--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -20,7 +20,6 @@
             imJs.mobileMenuActive();
             imJs.vedioActivation();
             imJs.stickyHeader();
-            imJs.smothScroll();
             imJs.smothScroll_Two();
             imJs.stickyAdjust();
             imJs.testimonialActivation();
@@ -92,15 +91,6 @@
         
         wowActive: function () {
             new WOW().init();
-        },
-
-        smothScroll: function () {
-            $(document).on('click', '.smoth-animation', function (event) {
-                event.preventDefault();
-                $('html, body').animate({
-                    scrollTop: $($.attr(this, 'href')).offset().top - 50
-                }, 300);
-            });
         },
         // two scroll spy
         smothScroll_Two: function () {
@@ -366,7 +356,7 @@
 
             function close_video() {
                 $('.video-overlay.open').removeClass('open').find('iframe').remove();
-            };
+            }
         },
 
         mobileMenuActive: function (e) {

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -30,7 +30,7 @@
               >
                 <a
                     :href="item.href"
-                    class="nav-link smoth-animation"
+                    class="nav-link"
                     :class="{ active: activeId === item.href }"
                     @click.prevent="scrollTo(item.href)"
                 >
@@ -71,14 +71,7 @@ export default {
   },
   methods: {
     scrollTo(href) {
-      const el = document.querySelector(href);
-      if (el) {
-        const top = el.offsetTop - 80;
-        window.scrollTo({
-          top,
-          behavior: "smooth"
-        });
-      }
+      document.querySelector(href)?.scrollIntoView({ behavior: 'smooth' });
     },
     trackActiveSection() {
       const scrollY = window.scrollY + 100;
@@ -122,7 +115,4 @@ export default {
   color: white;
 }
 
-.smoth-animation {
-  scroll-behavior: smooth;
-}
 </style>


### PR DESCRIPTION
## Summary
- use `scrollIntoView` for navigation scrolling
- drop jQuery `smothScroll` handler and its `.smoth-animation` class
- confirm section IDs align with navbar anchors

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: lint errors in vendor scripts)*

------
https://chatgpt.com/codex/tasks/task_e_68a59e7051f0832395308e8820c1e2cd