### PR TITLE
Improve responsive layout and mobile navigation

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+src/assets/js/**

--- a/src/assets/css/responsive.css
+++ b/src/assets/css/responsive.css
@@ -1,0 +1,32 @@
+/* Basic responsive utilities */
+img {
+  max-width: 100%;
+  height: auto;
+}
+
+/* Mobile navigation styles */
+.mobile-menu {
+  background-color: #1e1e1e;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  z-index: 999;
+  padding: 1rem;
+}
+.mobile-menu .nav-link {
+  padding: 0.5rem 0;
+  color: #aaa;
+}
+.mobile-menu .nav-link.active {
+  color: #fff;
+}
+.menu-toggle {
+  background: none;
+  border: none;
+  color: #fff;
+}
+.menu-toggle i {
+  width: 24px;
+  height: 24px;
+}

--- a/src/components/AboutMe.vue
+++ b/src/components/AboutMe.vue
@@ -62,7 +62,7 @@
             <div class="order-1 order-xl-2 col-lg-12 col-xl-7">
               <div class="background-image-area">
                 <div class="thumbnail-image">
-                  <img src="@/assets/images/slider/banner2.png" alt="Personal Portfolio" style="width: 672px; height: 505px" />
+                  <img src="@/assets/images/slider/banner2.png" alt="Personal Portfolio" class="img-fluid" />
                 </div>
               </div>
             </div>

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -3,7 +3,7 @@
     <div class="container pb--80 pb_sm--40 plr_sm--20">
       <div class="row">
         <div class="col-xl-3 col-12 col-lg-3 col-md-6 col-sm-6 col-12">
-          <div class="logo" style="width: 90px; height: 90px">
+          <div class="logo">
             <router-link to="/">
               <img src="@/assets/images/avatar.png" alt="logo" />
             </router-link>
@@ -77,5 +77,13 @@ export default {
 </script>
 
 <style>
+.logo {
+  width: 90px;
+  height: 90px;
+}
 
+.logo img {
+  width: 100%;
+  height: auto;
+}
 </style>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -10,8 +10,8 @@
       <!-- Left Logo -->
       <div class="col-lg-2 col-6">
         <div class="header-left">
-          <div class="logo" style="width: 90px; height: 90px">
-            <router-link to="/">
+          <div class="logo">
+            <router-link to="/" @click.native.prevent="scrollToTop">
               <img src="@/assets/images/avatar.png" alt="logo" />
             </router-link>
           </div>
@@ -20,7 +20,10 @@
 
       <!-- Center Nav -->
       <div class="col-lg-10 col-6">
-        <div class="header-center d-flex justify-content-between align-items-center float-end">
+        <div class="header-center d-flex justify-content-end justify-content-xl-between align-items-center float-end">
+          <button class="menu-toggle d-block d-xl-none" @click="toggleMenu">
+            <i data-feather="menu"></i>
+          </button>
           <nav id="sideNav" class="mainmenu-nav navbar-example2 d-none d-xl-block onepagenav">
             <ul class="primary-menu nav ">
               <li
@@ -51,6 +54,32 @@
         </div>
       </div>
     </div>
+
+    <div v-if="isMenuOpen" class="mobile-menu d-block d-xl-none">
+      <ul class="primary-menu nav flex-column">
+        <li
+            v-for="item in navItems"
+            :key="item.href"
+            class="nav-item"
+        >
+          <a
+              :href="item.href"
+              class="nav-link"
+              :class="{ active: activeId === item.href }"
+              @click.prevent="scrollTo(item.href)"
+          >
+            {{ $t(item.key) }}
+          </a>
+        </li>
+        <li class="nav-item mt-3">
+          <b-dropdown :text="$i18n.locale.toUpperCase()" variant="outline-light" size="sm">
+            <b-dropdown-item @click="switchLanguage('en')">EN</b-dropdown-item>
+            <b-dropdown-item @click="switchLanguage('ru')">RU</b-dropdown-item>
+            <b-dropdown-item @click="switchLanguage('uz')">UZ</b-dropdown-item>
+          </b-dropdown>
+        </li>
+      </ul>
+    </div>
   </header>
 </template>
 
@@ -61,6 +90,7 @@ export default {
     return {
       scrollTop: 0,
       activeId: "#home",
+      isMenuOpen: false,
       navItems: [
         { key: 'nav.home', href: '#home' },
         { key: 'nav.experience', href: '#experiences' },
@@ -75,6 +105,7 @@ export default {
   methods: {
     scrollTo(href) {
       document.querySelector(href)?.scrollIntoView({ behavior: 'smooth' });
+      this.isMenuOpen = false;
     },
     trackActiveSection() {
       const scrollY = window.scrollY + 100;
@@ -87,6 +118,13 @@ export default {
     },
     onScroll() {
       this.scrollTop = window.scrollY
+    },
+    toggleMenu() {
+      this.isMenuOpen = !this.isMenuOpen;
+    },
+    scrollToTop() {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+      this.isMenuOpen = false;
     },
     switchLanguage(lang) {
       this.$i18n.locale = lang
@@ -104,6 +142,9 @@ export default {
 </script>
 
 <style scoped>
+header {
+  position: relative;
+}
 .rn-header {
   background-color: #1e1e1e;
   padding: 0.75rem 1.5rem;
@@ -119,6 +160,16 @@ export default {
 
 .primary-menu .nav-link.active {
   color: white;
+}
+
+.logo {
+  width: 90px;
+  height: 90px;
+}
+
+.logo img {
+  width: 100%;
+  height: auto;
 }
 
 </style>

--- a/src/components/Portfolio.vue
+++ b/src/components/Portfolio.vue
@@ -12,7 +12,7 @@
 
       <div class="row mt--25 mt_md--5 mt_sm--5">
         <div class="col-lg-12">
-          <swiper :options="swiperOptions" class="portfolio-swiper">
+          <swiper v-if="!isMobile" :options="swiperOptions" class="portfolio-swiper">
             <!-- Slides -->
             <swiper-slide v-for="(item, i) in items" :key="i">
               <div class="rn-portfolio" @click="openItem(item)">
@@ -46,6 +46,37 @@
             <div class="swiper-button-prev slick-arrow-style-one slick-arrow" slot="button-prev"></div>
             <div class="swiper-button-next slick-arrow-style-one slick-arrow" slot="button-next"></div>
           </swiper>
+          <div v-else class="portfolio-list">
+            <div
+              class="rn-portfolio"
+              v-for="(item, i) in items"
+              :key="i"
+              @click="openItem(item)"
+            >
+              <div class="inner">
+                <div class="thumbnail">
+                  <a href="javascript:void(0)">
+                    <img :src="item.imageSrc" :alt="item.title" />
+                  </a>
+                </div>
+                <div class="content">
+                  <div class="category-info">
+                    <div class="category-list">
+                      <a href="javascript:void(0)">{{ item.category }}</a>
+                    </div>
+                    <div class="meta">
+                      <span><i class="feather-heart"></i> {{ item.likes }}</span>
+                    </div>
+                  </div>
+                  <h4 class="title">
+                    <a href="javascript:void(0)">{{ item.title }}
+                      <i class="feather-arrow-up-right"></i>
+                    </a>
+                  </h4>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -105,6 +136,7 @@ export default {
     return {
       showModal: false,
       currentItem: null,
+      isMobile: false,
       items: [
         {
           image: 'portfolio-erpp.png',
@@ -215,6 +247,13 @@ export default {
   created() {
     this.items = this.itemsWithSrc
   },
+  mounted() {
+    this.handleResize()
+    window.addEventListener('resize', this.handleResize)
+  },
+  beforeDestroy() {
+    window.removeEventListener('resize', this.handleResize)
+  },
   methods: {
     openItem(item) {
       this.currentItem = item
@@ -222,6 +261,9 @@ export default {
       if (window.feather && window.feather.replace) {
         this.$nextTick(() => window.feather.replace())
       }
+    },
+    handleResize() {
+      this.isMobile = window.innerWidth < 768
     }
   }
 }
@@ -229,6 +271,12 @@ export default {
 
 <style scoped>
 .portfolio-swiper { width: 100%; }
+
+.portfolio-list {
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+}
 
 .rn-portfolio {
   background: #1e1e1e;

--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,7 @@ import App from './App.vue'
 import router from './router/routes'
 import 'bootstrap/dist/css/bootstrap.min.css';
 import '@/assets/css/style.css';
+import '@/assets/css/responsive.css';
 import 'bootstrap/dist/css/bootstrap.css'
 import 'bootstrap-vue/dist/bootstrap-vue.css'
 import { BootstrapVue } from 'bootstrap-vue'


### PR DESCRIPTION
## Summary
- Ensure images scale across devices with new responsive stylesheet
- Add mobile-friendly hamburger navigation and top-scroll logo
- Clean up linting for vendor scripts
- Stack portfolio items vertically on small screens

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad90e115608323b2bee8ff6180d8a0