### PR TITLE
Add theme toggle with persistent light and dark modes

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="app">
-    <Header />
+    <Header :theme="theme" @toggle-theme="toggleTheme" />
     <router-view />
     <Footer />
     <!-- Back to top -->
@@ -13,13 +13,14 @@
 <script>
 import Header from './components/Header.vue'
 import Footer from './components/Footer.vue'
-import { ref, onMounted, onUnmounted } from 'vue'
+import { ref, onMounted, onUnmounted, watch } from 'vue'
 
 export default {
   name: 'App',
   components: { Header, Footer },
   setup() {
     const backToTopVisible = ref(false)
+    const theme = ref('dark')
 
     const scrollToTop = () => {
       window.scrollTo({ top: 0, behavior: 'smooth' })
@@ -29,11 +30,32 @@ export default {
       backToTopVisible.value = window.scrollY > 200
     }
 
+    const applyTheme = value => {
+      if (typeof document === 'undefined') return
+      const body = document.body
+      body.classList.remove('template-color-1', 'white-version')
+      body.classList.add(value === 'light' ? 'white-version' : 'template-color-1')
+      body.classList.add('spybody')
+    }
+
+    const toggleTheme = () => {
+      theme.value = theme.value === 'dark' ? 'light' : 'dark'
+    }
+
     onMounted(() => {
-      document.body.classList.add('template-color-1', 'spybody')
-      document.body.setAttribute('data-spy', 'scroll')
-      document.body.setAttribute('data-bs-target', '.navbar-example2')
-      document.body.setAttribute('data-offset', '150')
+      const savedTheme = typeof window !== 'undefined'
+        ? window.localStorage.getItem('preferred-theme')
+        : null
+      if (savedTheme === 'light' || savedTheme === 'dark') {
+        theme.value = savedTheme
+      }
+
+      applyTheme(theme.value)
+      if (typeof document !== 'undefined') {
+        document.body.setAttribute('data-spy', 'scroll')
+        document.body.setAttribute('data-bs-target', '.navbar-example2')
+        document.body.setAttribute('data-offset', '150')
+      }
 
       import('feather-icons').then(feather => feather.replace())
       window.addEventListener('scroll', handleScroll)
@@ -43,7 +65,14 @@ export default {
       window.removeEventListener('scroll', handleScroll)
     })
 
-    return { scrollToTop, backToTopVisible }
+    watch(theme, newTheme => {
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem('preferred-theme', newTheme)
+      }
+      applyTheme(newTheme)
+    })
+
+    return { scrollToTop, backToTopVisible, theme, toggleTheme }
   }
 }
 </script>
@@ -52,30 +81,15 @@ html {
   scroll-behavior: smooth;
 }
 .backto-top {
-  position: fixed;
-  bottom: 20px;
-  right: 20px;
-  width: 40px;
-  height: 40px;
-  background-color: #333;
-  color: #fff;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  border-radius: 50%;
-  cursor: pointer;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
-  transition: opacity 0.3s;
   opacity: 0;
   visibility: hidden;
+  pointer-events: none;
+  transition: opacity 0.3s ease, visibility 0.3s ease;
 }
 
 .backto-top.show {
   opacity: 1;
   visibility: visible;
-}
-
-.backto-top i {
-  font-size: 18px;
+  pointer-events: auto;
 }
 </style>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -4,7 +4,8 @@
       'black-logo-version',
       'header--sticky',
       'p-3',
-      scrollTop > 50 ? 'rn-header' : ''
+      scrollTop > 50 ? 'rn-header' : '',
+      themeClass
     ]">
     <div class="header-wrapper rn-popup-mobile-menu m--0 row align-items-center h-25">
       <!-- Left Logo -->
@@ -44,8 +45,17 @@
           </nav>
 
           <!-- Language switcher -->
-          <div class="header-right d-none d-xl-block">
-            <b-dropdown :text="$i18n.locale.toUpperCase()" variant="outline-light" size="sm">
+          <div class="header-right d-none d-xl-flex align-items-center gap-2">
+            <button
+                type="button"
+                class="theme-toggle"
+                @click="toggleTheme"
+                :aria-label="theme === 'dark' ? $t('theme.switchToLight') : $t('theme.switchToDark')"
+            >
+              <i :data-feather="theme === 'dark' ? 'sun' : 'moon'"></i>
+              <span>{{ theme === 'dark' ? $t('theme.switchToLight') : $t('theme.switchToDark') }}</span>
+            </button>
+            <b-dropdown :text="$i18n.locale.toUpperCase()" :variant="dropdownVariant" size="sm">
               <b-dropdown-item @click="switchLanguage('en')">EN</b-dropdown-item>
               <b-dropdown-item @click="switchLanguage('ru')">RU</b-dropdown-item>
               <b-dropdown-item @click="switchLanguage('uz')">UZ</b-dropdown-item>
@@ -72,7 +82,17 @@
           </a>
         </li>
         <li class="nav-item mt-3">
-          <b-dropdown :text="$i18n.locale.toUpperCase()" variant="outline-light" size="sm">
+          <button
+              type="button"
+              class="theme-toggle w-100 justify-content-center"
+              @click="handleMobileThemeToggle"
+          >
+            <i :data-feather="theme === 'dark' ? 'sun' : 'moon'"></i>
+            <span>{{ theme === 'dark' ? $t('theme.switchToLight') : $t('theme.switchToDark') }}</span>
+          </button>
+        </li>
+        <li class="nav-item mt-3">
+          <b-dropdown :text="$i18n.locale.toUpperCase()" :variant="dropdownVariant" size="sm">
             <b-dropdown-item @click="switchLanguage('en')">EN</b-dropdown-item>
             <b-dropdown-item @click="switchLanguage('ru')">RU</b-dropdown-item>
             <b-dropdown-item @click="switchLanguage('uz')">UZ</b-dropdown-item>
@@ -84,8 +104,16 @@
 </template>
 
 <script>
+import feather from 'feather-icons'
+
 export default {
   name: "Header",
+  props: {
+    theme: {
+      type: String,
+      default: 'dark'
+    }
+  },
   data() {
     return {
       scrollTop: 0,
@@ -128,16 +156,45 @@ export default {
     },
     switchLanguage(lang) {
       this.$i18n.locale = lang
+    },
+    toggleTheme() {
+      this.$emit('toggle-theme')
+    },
+    handleMobileThemeToggle() {
+      this.toggleTheme()
+      this.isMenuOpen = false
+    },
+    refreshIcons() {
+      this.$nextTick(() => {
+        feather.replace()
+      })
     }
   },
   mounted() {
     window.addEventListener("scroll", this.trackActiveSection);
     window.addEventListener('scroll', this.onScroll)
+    this.refreshIcons()
   },
   beforeDestroy() {
     window.removeEventListener("scroll", this.trackActiveSection);
     window.removeEventListener('scroll', this.onScroll)
   },
+  computed: {
+    themeClass() {
+      return this.theme === 'light' ? 'light-mode' : 'dark-mode'
+    },
+    dropdownVariant() {
+      return this.theme === 'light' ? 'outline-dark' : 'outline-light'
+    }
+  },
+  watch: {
+    theme() {
+      this.refreshIcons()
+    },
+    isMenuOpen() {
+      this.refreshIcons()
+    }
+  }
 };
 </script>
 
@@ -145,10 +202,28 @@ export default {
 header {
   position: relative;
 }
+
 .rn-header {
   background-color: #1e1e1e;
   padding: 0.75rem 1.5rem;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+header.light-mode {
+  color: #1f2937;
+}
+
+header.light-mode .rn-header {
+  background-color: #ffffff;
+  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.1);
+}
+
+header.light-mode .primary-menu .nav-link {
+  color: #4b5563;
+}
+
+header.light-mode .primary-menu .nav-link.active {
+  color: #0f172a;
 }
 
 .primary-menu .nav-link {
@@ -160,6 +235,48 @@ header {
 
 .primary-menu .nav-link.active {
   color: white;
+}
+
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  border: none;
+  border-radius: 999px;
+  padding: 0.35rem 0.85rem;
+  background: rgba(255, 255, 255, 0.08);
+  color: inherit;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+.theme-toggle i {
+  width: 20px;
+  height: 20px;
+}
+
+.theme-toggle span {
+  white-space: nowrap;
+  font-weight: 500;
+}
+
+header.dark-mode .theme-toggle:hover {
+  background: rgba(255, 255, 255, 0.16);
+}
+
+header.light-mode .theme-toggle {
+  background: rgba(15, 23, 42, 0.08);
+  color: #0f172a;
+}
+
+header.light-mode .theme-toggle:hover {
+  background: rgba(15, 23, 42, 0.16);
+}
+
+.mobile-menu .theme-toggle {
+  width: 100%;
+  justify-content: center;
 }
 
 .logo {

--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -6,18 +6,10 @@
     <ResumeSection/>
     <PortfolioSection/>
     <Blog />
-    <!-- Back to top Start -->
-    <div class="backto-top" @click="scrollToTop" :class="{ show: backToTopVisible }">
-      <div>
-        <i data-feather="arrow-up"></i>
-      </div>
-    </div>
-    <!-- Back to top End -->
   </div>
 </template>
 
 <script>
-import { ref, onMounted, onUnmounted } from 'vue';
 import AboutMe from "@/components/AboutMe.vue";
 import Blog from "@/components/Blog.vue";
 import ExperienceSection from "@/components/Experience.vue";
@@ -26,7 +18,7 @@ import ResumeSection from "@/components/Resume.vue";
 import PortfolioSection from "@/components/Portfolio.vue";
 
 export default {
-  name: 'App',
+  name: 'Home',
   components: {
     PortfolioSection,
     ResumeSection,
@@ -34,74 +26,6 @@ export default {
     ExperienceSection,
     Blog,
     AboutMe,
-  },
-  setup() {
-    const backToTopVisible = ref(false);
-
-    const scrollToTop = () => {
-      window.scrollTo({
-        top: 0,
-        behavior: 'smooth'
-      });
-    };
-
-    const handleScroll = () => {
-      backToTopVisible.value = window.scrollY > 200;
-    };
-
-    onMounted(() => {
-      document.body.classList.add('template-color-1', 'spybody');
-      document.body.setAttribute('data-spy', 'scroll');
-      document.body.setAttribute('data-bs-target', '.navbar-example2');
-      document.body.setAttribute('data-offset', '150');
-
-      // Initialize Feather icons
-      import('feather-icons').then((feather) => {
-        feather.replace();
-      });
-
-      window.addEventListener('scroll', handleScroll);
-    });
-
-    onUnmounted(() => {
-      window.removeEventListener('scroll', handleScroll);
-    });
-
-    return {
-      scrollToTop,
-      backToTopVisible
-    };
   }
 }
 </script>
-
-<style>
-/* Your global styles here */
-.backto-top {
-  position: fixed;
-  bottom: 20px;
-  right: 20px;
-  width: 40px;
-  height: 40px;
-  background-color: #333;
-  color: #fff;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  border-radius: 50%;
-  cursor: pointer;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
-  transition: opacity 0.3s;
-  opacity: 0;
-  visibility: hidden;
-}
-
-.backto-top.show {
-  opacity: 1;
-  visibility: visible;
-}
-
-.backto-top i {
-  font-size: 18px;
-}
-</style>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -8,6 +8,10 @@
     "blog": "Blog",
     "footer": "Footer"
   },
+  "theme": {
+    "switchToLight": "Light mode",
+    "switchToDark": "Dark mode"
+  },
   "hero": {
     "greeting": "Hi, I’m",
     "name": "Azizjon",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -8,6 +8,10 @@
     "blog": "Блог",
     "footer": "Футер"
   },
+  "theme": {
+    "switchToLight": "Светлая тема",
+    "switchToDark": "Тёмная тема"
+  },
   "hero": {
     "greeting": "Привет, я",
     "name": "Азизжон",

--- a/src/locales/uz.json
+++ b/src/locales/uz.json
@@ -8,6 +8,10 @@
     "blog": "Blog",
     "footer": "Futer"
   },
+  "theme": {
+    "switchToLight": "Yorug' rejim",
+    "switchToDark": "Qorong'i rejim"
+  },
   "hero": {
     "greeting": "Salom, men",
     "name": "Azizjon",


### PR DESCRIPTION
## Summary
- add global theme management with persistence and back-to-top styling updates
- integrate a navbar theme toggle for desktop and mobile, refreshing icons as needed
- translate the theme labels for English, Russian, and Uzbek locales and simplify the home page wrapper

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5159211a48323adb9357e3dc0a354